### PR TITLE
Update 1.20.0

### DIFF
--- a/recipe/001-Missing-Build-System.patch
+++ b/recipe/001-Missing-Build-System.patch
@@ -1,0 +1,13 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 7be5572..0d94d57 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -63,6 +63,8 @@ wrapt = ">=1.15.0"
+
+ [tool.black]
+ line-length = 90
++
++[build-system]
+ requires = ["poetry-core"]
+ build-backend = "poetry.core.masonry.api"
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,18 +8,23 @@ package:
 source:
   url: https://github.com/signalfx/splunk-otel-python/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 84fe14c6f9d71a2bae83c04beea2287bc41e78185c1bd6d1f6385640a953adc6
+  patches:
+    - 001-Missing-Build-System.patch
 
 build:
-  # entry_points:
-  #   - splunk-py-trace = splunk_otel.cmd.trace:run
-  #   - splunk-py-trace-bootstrap = splunk_otel.cmd.bootstrap:run
-  #   - splk-py-trace = splunk_otel.cmd.trace:run_deprecated
-  #   - splk-py-trace-bootstrap = splunk_otel.cmd.bootstrap:run_deprecated
+  entry_points:
+    - splunk-py-trace = splunk_otel.cmd.trace:run
+    - splunk-py-trace-bootstrap = splunk_otel.cmd.bootstrap:run
+    - splk-py-trace = splunk_otel.cmd.trace:run_deprecated
+    - splk-py-trace-bootstrap = splunk_otel.cmd.bootstrap:run_deprecated
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
   number: 0
   skip: True # [py<38]
 
 requirements:
+  build:
+    - m2-patch  # [win]
+    - patch  # [not win]
   host:
     - python
     - poetry-core
@@ -41,11 +46,19 @@ requirements:
 
 test:
   imports:
-    - splunk_otel.tests
+    - splunk_otel
+  #   - opentelemetry_instrumentation
+  #   - opentelemetry_sdk
+  # #   - splunk_otel.profiling
   commands:
+    # - ls -la
+    # - pytest tests
     - pip check
   requires:
     - pip
+    # - opentelemetry-sdk
+    # - opentelemetry-instrumentation
+    # - pytest
 
 about:
   home: https://github.com/signalfx/splunk-otel-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,8 +29,6 @@ requirements:
     - python
     - poetry-core
     - pip
-    - setuptools
-    - wheel
   run:
     - python
     - cryptography >=2.0,<=43.0.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
 
 test:
   imports:
-    - splunk_otel
+    - splunk_otel.tests
   commands:
     - pip check
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,63 @@
+{% set name = "splunk-opentelemetry" %}
+{% set version = "1.20.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/signalfx/splunk-otel-python/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 84fe14c6f9d71a2bae83c04beea2287bc41e78185c1bd6d1f6385640a953adc6
+
+build:
+  # entry_points:
+  #   - splunk-py-trace = splunk_otel.cmd.trace:run
+  #   - splunk-py-trace-bootstrap = splunk_otel.cmd.bootstrap:run
+  #   - splk-py-trace = splunk_otel.cmd.trace:run_deprecated
+  #   - splk-py-trace-bootstrap = splunk_otel.cmd.bootstrap:run_deprecated
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
+  number: 0
+  skip: True # [py<38]
+
+requirements:
+  host:
+    - python
+    - poetry-core
+    - pip
+    - setuptools
+    - wheel
+  run:
+    - python
+    - cryptography >=2.0,<=43.0.1
+    - protobuf >=4.23.0,<5.0.0
+    - opentelemetry-api 1.26.0
+    - opentelemetry-sdk 1.26.0
+    - opentelemetry-instrumentation 0.47b0
+    - opentelemetry-instrumentation-system-metrics 0.47b0
+    - opentelemetry-semantic-conventions 0.47b0
+    - opentelemetry-propagator-b3 1.26.0
+    - opentelemetry-exporter-otlp-proto-grpc 1.26.0
+    - opentelemetry-exporter-otlp-proto-http 1.26.0
+
+test:
+  imports:
+    - splunk_otel
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/signalfx/splunk-otel-python
+  summary: The Splunk distribution of OpenTelemetry Python Instrumentation provides a Python agent that automatically instruments your Python application to capture and report distributed traces to SignalFx APM.
+  license: Apache-2.0
+  license_file: LICENSE
+  license_family: Apache
+  description: |
+    This package provides entrypoints to configure OpenTelemetry.
+  doc_url: https://github.com/signalfx/splunk-otel-python/tree/main/docs
+  dev_url:
+
+extra:
+  recipe-maintainers:
+    - Arishamays1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,18 +47,10 @@ requirements:
 test:
   imports:
     - splunk_otel
-  #   - opentelemetry_instrumentation
-  #   - opentelemetry_sdk
-  # #   - splunk_otel.profiling
   commands:
-    # - ls -la
-    # - pytest tests
     - pip check
   requires:
     - pip
-    # - opentelemetry-sdk
-    # - opentelemetry-instrumentation
-    # - pytest
 
 about:
   home: https://github.com/signalfx/splunk-otel-python
@@ -69,7 +61,7 @@ about:
   description: |
     This package provides entrypoints to configure OpenTelemetry.
   doc_url: https://github.com/signalfx/splunk-otel-python/tree/main/docs
-  dev_url:
+  dev_url: https://github.com/signalfx/splunk-otel-python
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
> ## ☆splunk-opentelemetry 1.20.0☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-2423) 
> [Upstream](https://github.com/signalfx/splunk-otel-python/tree/v1.20.0)
> 
> ### Changes
> * Updated version number and sha256
> * Updated dependencies for `run` and `host` 
> * Added `001-Missing-Build-System` patch to upstream's `pyproject.toml` to include the missing `[build-system]` header